### PR TITLE
Add arguments required by IE for createTreeWalker

### DIFF
--- a/src/util.coffee
+++ b/src/util.coffee
@@ -62,7 +62,7 @@ Util.getLastTextNodeUpTo = (n) ->
 Util.getTextNodes = (jq) ->
   getTextNodes = (root) ->
     document = root.ownerDocument
-    walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT)
+    walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT, null, false)
     nodes = (node while node = walker.nextNode())
     return nodes
 


### PR DESCRIPTION
Internet Explorer requires all four arguments be passed to the `document.createTreeWalker` method. Thus, `Util#getTextNodes` was throwing an uncaught error in IE. This fixes that by passing default values for the missing arguments.