### PR TITLE
Don’t assume start node has a nextSibling

### DIFF
--- a/src/range.coffee
+++ b/src/range.coffee
@@ -77,7 +77,9 @@ class Range.BrowserRange
         nr.start = r.start.splitText(r.startOffset)
       else
         # Avoid splitting off zero-length pieces.
-        nr.start = r.start.nextSibling
+        previousNode = r.start
+        previousNode = previousNode.parentNode until previousNode.nextSibling
+        nr.start = previousNode.nextSibling
     else
       nr.start = r.start
 


### PR DESCRIPTION
If a range start offset is at the very end of its container node, we want to move the cursor forward to the beginning of the next node in the DOM.  However, the next node is not necessarily a sibling of the start container reported by the browser; it may be a sibling of its parent, its parent’s parent, etc. So, be sure to move up the tree until we find a node that has a next sibling.